### PR TITLE
Add back code coverage example, using nyc

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ Pass the Chrome **--no-sandbox** and **--disable-setuid-sandbox** arguments:
 $ mocha-headless-chrome -f test.html -a no-sandbox -a disable-setuid-sandbox
 ```
 
+Instrument `src/` code with `istanbul`, run tests on it, and coverage the generated `coverage.json` to an HTML report:
+
+_First, instrument your `.js` files with `istanbul`, then create a test HTML file pointing to the instrumented equivalents:_
+
+```
+istanbul instrument src -o instrumented
+sed "s/.js/.instrumented.js/" test.html > test.instrumented.html
+```
+
+_Run `mocha-headless-chrome` with `-c`/`--coverage` on the instrumented tests:_
+
+```
+$ mocha-headless-chrome -c coverage.json -f test.instrumented.html
+$ istanbul report html
+```
+
 ## Mocha reporters
 
 All mocha reporters are supported. Specify the reporter name through **-r** parameter. All reporter output (include cursor manipulations) will be redirected to stdout as like it works in console.

--- a/README.md
+++ b/README.md
@@ -67,21 +67,43 @@ Pass the Chrome **--no-sandbox** and **--disable-setuid-sandbox** arguments:
 $ mocha-headless-chrome -f test.html -a no-sandbox -a disable-setuid-sandbox
 ```
 
-Instrument `src/` code with `istanbul`, run tests on it, and coverage the generated `coverage.json` to an HTML report:
+### Computing and reporting test coverage
 
-_First, instrument your `.js` files with `istanbul`, then create a test HTML file pointing to the instrumented equivalents:_
+In order to get information from the **-c** option of mocha-headless-chrome,
+you'll need to first
+[instrument](https://en.wikipedia.org/wiki/Instrumentation_(computer_programming))
+your source code. This will produce modified versions of your source code
+file(s), which you'll need to modify your HTML file to use.
+
+Here, we show how to do this with [nyc](https://github.com/istanbuljs/nyc).
 
 ```
-istanbul instrument src -o instrumented
-sed "s/.js/.instrumented.js/" test.html > test.instrumented.html
+# Produce an instrumented version of your source code
+$ nyc instrument example/example-tests.js > example/example-tests.instrumented.js
+
+# Modify the HTML file to point to the instrumented version
+$ sed "s/example-tests.js/example-tests.instrumented.js/" example/example-page.html > example/example-page.instrumented.html
 ```
 
-_Run `mocha-headless-chrome` with `-c`/`--coverage` on the instrumented tests:_
+Now, we can run `mocha-headless-chrome` with **-c** using the instrumented code:
 
 ```
-$ mocha-headless-chrome -c coverage.json -f test.instrumented.html
-$ istanbul report html
+$ mocha-headless-chrome -c coverage.json -f example/example-page.instrumented.html
 ```
+
+This produces a `coverage.json` file. If you're using a tool like [Codecov](http://codecov.io/), it should be able to detect this file by itself.
+
+We can also generate a human-readable report of the code coverage as follows:
+
+```
+mkdir .nyc_output
+mv coverage.json nyc_output/
+nyc report
+```
+
+If you'd like, you can use the `--reporter` option of `nyc report` to change
+the format of this report (e.g. using `--reporter html` will generate a HTML
+report in the `coverage/` directory).
 
 ## Mocha reporters
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ file(s), which you'll need to modify your HTML file to use.
 Here, we show how to do this with [nyc](https://github.com/istanbuljs/nyc).
 
 ```bash
+# Install nyc
+$ npm install -g nyc
 # Produce an instrumented version of your source code
 $ nyc instrument example/example-tests.js > example/example-tests.instrumented.js
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ file(s), which you'll need to modify your HTML file to use.
 
 Here, we show how to do this with [nyc](https://github.com/istanbuljs/nyc).
 
-```
+```bash
 # Produce an instrumented version of your source code
 $ nyc instrument example/example-tests.js > example/example-tests.instrumented.js
 
@@ -87,7 +87,7 @@ $ sed "s/example-tests.js/example-tests.instrumented.js/" example/example-page.h
 
 Now, we can run `mocha-headless-chrome` with **-c** using the instrumented code:
 
-```
+```bash
 $ mocha-headless-chrome -c coverage.json -f example/example-page.instrumented.html
 ```
 
@@ -95,7 +95,7 @@ This produces a `coverage.json` file. If you're using a tool like [Codecov](http
 
 We can also generate a human-readable report of the code coverage as follows:
 
-```
+```bash
 mkdir .nyc_output
 mv coverage.json nyc_output/
 nyc report

--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ $ mocha-headless-chrome -c coverage.json -f example/example-page.instrumented.ht
 This produces a `coverage.json` file. If you're using a tool like [Codecov](http://codecov.io/), it should be able to detect this file by itself.
 
 We can also generate a human-readable report of the code coverage as follows:
+(nyc expects coverage information to be in an `.nyc_output/` directory.)
 
 ```bash
 mkdir .nyc_output
-mv coverage.json nyc_output/
+mv coverage.json .nyc_output/
 nyc report
 ```
 


### PR DESCRIPTION
This adds back @JoshuaKGoldberg's examples of computing and reporting on code coverage. I've updated his example to:

1. Use a non-deprecated tool (`nyc` instead of `istanbul`), as discussed in #22
2. Compute coverage of the `example-tests.js` code already in the repository (this lets users try this out immediately).

Let me know if you'd like me to make any changes.

Also: thanks all for your work on this repository! It's been super helpful :)