### PR TITLE
Fix a vulnerability issue with puppeteer

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "args": "^5.0.0",
     "mkdirp": "^0.5.1",
-    "puppeteer": "1.12.2"
+    "puppeteer": "^1.17.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
A high risk vulnerability has been found in the currently included "puppeteer" package.

 
=== npm audit security report === 
┌───────────────┬───────────────────────────────────────┐
│ High                               │ Use-After-Free                                                                          │
├───────────────┼───────────────────────────────────────┤
│ Package       │ puppeteer                             │
├───────────────┼───────────────────────────────────────┤
│ Patched in    │ >=1.13.0                              │
├───────────────┼───────────────────────────────────────┤
│ Dependency of │ mocha-headless-chrome [dev]           │
├───────────────┼───────────────────────────────────────┤
│ Path          │ mocha-headless-chrome > puppeteer     │
├───────────────┼───────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/824      │
└───────────────┴───────────────────────────────────────┘


This is an issue that needs to be resolved when version v1.13.0 or later is installed.
I changed the package dependency to the latest version (1.17.0) 
and confirmed that it works the same as before.