### PR TITLE
Don't write empty lines to console with newline

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -135,7 +135,7 @@ function handleConsole(msg) {
             isStdout && (args = args.slice(1));
             //
             let msg = util.format(...args);
-            !isStdout && (msg += '\n');
+            !isStdout && msg && (msg += '\n');
             process.stdout.write(msg);
         });
 }


### PR DESCRIPTION
The behavior of the test runner is that for messages that don't go through the "stdout" wrapper in mocha is that it adds a newline.  In our test setup we periodically get random empty console events which causes the test output to be staggered.  I've updated the handleConsole event handler to not write in these situations.