### PR TITLE
Don't try to parse console output if it is an ElementHandle

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const util = require('util');
 const puppeteer = require('puppeteer');
+const ElementHandle = require('puppeteer/lib/JSHandle').ElementHandle;
 
 function initMocha(reporter) {
 
@@ -126,7 +127,7 @@ function configureViewport(width, height, page) {
 }
 
 function handleConsole(msg) {
-    const args = msg._args;
+    const args = msg._args.filter( a => !(a instanceof ElementHandle) );
 
     Promise.all(args.map(a => a.jsonValue()))
         .then(args => {


### PR DESCRIPTION
Calling jsonValue() can throw an exception for ElementHandles
if the node is not "stringifiable" (according to the Puppeteer
docs). I don't know what qualifies as "stringifiable" but an
page element being console.log'ed by a warning message in our
code was causing a thrown exception.

Relevant API docs for Puppeteer: https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#elementhandlejsonvalue