### PR TITLE
Remove the badge of David

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![npm](https://img.shields.io/npm/v/mocha-headless-chrome.svg)](https://www.npmjs.com/package/mocha-headless-chrome)
 [![license](https://img.shields.io/npm/l/mocha-headless-chrome.svg)](http://spdx.org/licenses/MIT.html)
-[![dependency status](https://img.shields.io/david/direct-adv-interfaces/mocha-headless-chrome.svg)](https://david-dm.org/direct-adv-interfaces/mocha-headless-chrome)
-[![dev dependency status](https://img.shields.io/david/dev/direct-adv-interfaces/mocha-headless-chrome.svg)](https://david-dm.org/direct-adv-interfaces/mocha-headless-chrome?type=dev)
 
 This is the tool which runs client-side [mocha](https://github.com/mochajs/mocha) tests in the command line through headless Chrome ([puppeteer](https://github.com/GoogleChrome/puppeteer) is used).
 


### PR DESCRIPTION
Due to the unreliability of its service (alanshaw/david#171) and questionable necessity (https://depfu.com/blog/rethinking-the-dependencies-badge).
![image](https://user-images.githubusercontent.com/32959831/174765242-4a004cf5-1e47-45dc-a94b-c9bf06226f26.png)
