### PR TITLE
Add support for chrome-headless-shell

### DIFF
--- a/lib/runner.d.ts
+++ b/lib/runner.d.ts
@@ -40,7 +40,7 @@ interface Options {
     /**
      * Whether to show the Chrome window.
      */
-    visible?: boolean;
+    visible?: boolean | 'shell';
     
     /**
      * Puppeteer polling mechanism.

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -193,7 +193,8 @@ exports.runner = function ({
 
     const options = {
       ignoreHTTPSErrors: true,
-      headless: !visible,
+      // puppeteer also supports headless-shell mode
+      headless: typeof visible === 'boolean' ? !visible : visible,
       executablePath,
       args,
     };


### PR DESCRIPTION
Recent version of puppeteer use a new headless mode for chrome that behaves differently that the legacy mode, with regards to drag and drop, and file selection for example.

You can still use the legacy mode by setting `headless: 'shell'` option when launching `puppeteer`.

See docs: https://pptr.dev/guides/headless-modes

In this support, I'm adding a way to enable `chrome-headless-shell` on the test runnner.